### PR TITLE
Change image values.yaml tree to fit renovate's quirks

### DIFF
--- a/charts/stateless-dns/ci/e2e-values.yaml
+++ b/charts/stateless-dns/ci/e2e-values.yaml
@@ -13,9 +13,10 @@ externalDNS:
   policy: sync
 
 pdns:
-  # We are going to test always with the version built or the latest stable
-  registry: ci.local
-  tag: ci
+  image:
+    # We are going to test always with the version built or the latest stable
+    registry: ci.local
+    tag: ci
 
   apiKeySecret:
     create: true

--- a/charts/stateless-dns/ci/test-all-possible-values-1.yaml
+++ b/charts/stateless-dns/ci/test-all-possible-values-1.yaml
@@ -80,9 +80,11 @@ externalDNS:
   nameOverride: ""
   fullnameOverride: ""
 
-  registry: registry.k8s.io
-  repository: external-dns/external-dns
-  tag: v0.13.1
+  image:
+    registry: registry.k8s.io
+    repository: external-dns/external-dns
+    tag: v0.13.1
+
   pullPolicy: IfNotPresent
 
   securityContext:
@@ -131,9 +133,11 @@ pdns:
   nameOverride: ""
   fullnameOverride: ""
 
-  registry: ghcr.io
-  repository: txqueuelen/stateless-dns
-  tag: ci  # We are going to test always with the version built or the latest stable
+  image:
+    registry: ghcr.io
+    repository: txqueuelen/stateless-dns
+    tag: ci  # We are going to test always with the version built or the latest stable
+
   pullPolicy: IfNotPresent
 
   securityContext:

--- a/charts/stateless-dns/ci/test-all-possible-values-1.yaml
+++ b/charts/stateless-dns/ci/test-all-possible-values-1.yaml
@@ -135,7 +135,7 @@ pdns:
 
   image:
     registry: ghcr.io
-    repository: txqueuelen/stateless-dns
+    repository: txqueuelen/stateless-dns/powerdns
     tag: ci  # We are going to test always with the version built or the latest stable
 
   pullPolicy: IfNotPresent

--- a/charts/stateless-dns/ci/test-all-possible-values-2.yaml
+++ b/charts/stateless-dns/ci/test-all-possible-values-2.yaml
@@ -80,9 +80,11 @@ externalDNS:
   nameOverride: ""
   fullnameOverride: ""
 
-  registry: registry.k8s.io
-  repository: external-dns/external-dns
-  tag: v0.13.1
+  image:
+    registry: registry.k8s.io
+    repository: external-dns/external-dns
+    tag: v0.13.1
+
   pullPolicy: IfNotPresent
 
   securityContext:
@@ -131,9 +133,11 @@ pdns:
   nameOverride: ""
   fullnameOverride: ""
 
-  registry: ghcr.io
-  repository: txqueuelen/stateless-dns
-  tag: ci  # We are going to test always with the version built or the latest stable
+  image:
+    registry: ghcr.io
+    repository: txqueuelen/stateless-dns
+    tag: ci  # We are going to test always with the version built or the latest stable
+
   pullPolicy: IfNotPresent
 
   securityContext:

--- a/charts/stateless-dns/ci/test-all-possible-values-2.yaml
+++ b/charts/stateless-dns/ci/test-all-possible-values-2.yaml
@@ -135,7 +135,7 @@ pdns:
 
   image:
     registry: ghcr.io
-    repository: txqueuelen/stateless-dns
+    repository: txqueuelen/stateless-dns/powerdns
     tag: ci  # We are going to test always with the version built or the latest stable
 
   pullPolicy: IfNotPresent

--- a/charts/stateless-dns/templates/external-dns-deployment.yaml
+++ b/charts/stateless-dns/templates/external-dns-deployment.yaml
@@ -51,7 +51,7 @@ spec:
       {{- end }}
       containers:
         - name: external-dns
-          image: "{{ .Values.externalDNS.registry }}/{{ .Values.externalDNS.repository }}:{{ .Values.externalDNS.tag }}"
+          image: "{{ .Values.externalDNS.image.registry }}/{{ .Values.externalDNS.image.repository }}:{{ .Values.externalDNS.image.tag }}"
           imagePullPolicy: {{ .Values.externalDNS.pullPolicy }}
           {{- with .Values.externalDNS.securityContext }}
           securityContext:

--- a/charts/stateless-dns/templates/pdns-deployment.yaml
+++ b/charts/stateless-dns/templates/pdns-deployment.yaml
@@ -52,7 +52,7 @@ spec:
       {{- end }}
       containers:
         - name: pdns
-          image: "{{ .Values.pdns.registry }}/{{ .Values.pdns.repository }}:{{ .Values.pdns.tag }}"
+          image: "{{ .Values.pdns.image.registry }}/{{ .Values.pdns.image.repository }}:{{ .Values.pdns.image.tag }}"
           imagePullPolicy: {{ .Values.pdns.pullPolicy }}
           {{- with .Values.pdns.securityContext }}
           securityContext:

--- a/charts/stateless-dns/values.yaml
+++ b/charts/stateless-dns/values.yaml
@@ -73,9 +73,11 @@ externalDNS:
   nameOverride: ""  # String to override the name of the objects created (will maintain the release name).
   fullnameOverride: ""  # String to override the name of the objects created.
 
-  registry: registry.k8s.io  # Image registry
-  repository: external-dns/external-dns  # Image repository
-  tag: v0.13.1  # Image tag
+  image:
+    registry: registry.k8s.io  # Image registry
+    repository: external-dns/external-dns  # Image repository
+    tag: v0.13.1  # Image tag
+
   pullPolicy: IfNotPresent  # Image pull policy.
 
   securityContext:
@@ -124,10 +126,11 @@ pdns:
   nameOverride: ""  # String to override the name of the objects created (will maintain the release name).
   fullnameOverride: ""  # String to override the name of the objects created.
 
-  registry: ghcr.io  # Image registry
-  repository: txqueuelen/stateless-dns/powerdns  # Image repository
-  tag: v4.5.3  # Image tag
-  pullPolicy: IfNotPresent  # Image pull policy.
+  image:
+    registry: ghcr.io  # Image registry
+    repository: txqueuelen/stateless-dns/powerdns  # Image repository
+    tag: v4.5.3  # Image tag
+    pullPolicy: IfNotPresent  # Image pull policy.
 
   securityContext:
     allowPrivilegeEscalation: false  # PowerDNS should not be able to escalete to root.


### PR DESCRIPTION
Renovate wants image "spec" to be an object with the parent key called `image`: https://github.com/renovatebot/renovate/blob/1615d262264fd5db4bee76802c3542bc0fd36556/lib/modules/manager/helm-values/util.ts#L5

This should make renovate detect dependencies in the values.