### PR TITLE
chart: remove bcrypt from secret hash

### DIFF
--- a/charts/stateless-dns/templates/pdns-deployment.yaml
+++ b/charts/stateless-dns/templates/pdns-deployment.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/apikey-secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum | bcrypt | quote }}
+        checksum/apikey-secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         checksum/zones: {{ include (print $.Template.BasePath "/zones-configmap.yaml") . | sha256sum }}
         checksum/config: {{ include (print $.Template.BasePath "/config-configmap.yaml") . | sha256sum }}
         {{- with .Values.podAnnotations }}


### PR DESCRIPTION
Bcrypt incorporates a random salt, which causes the checksum to change on each release. I still believe the unsalted sha256sum is a security risk, but typically not too high out of multi-tenant environments.

Closes #39 