### PR TITLE
chart: fix rendering of managedRecordTypes

### DIFF
--- a/charts/stateless-dns/ci/test-all-possible-values-1.yaml
+++ b/charts/stateless-dns/ci/test-all-possible-values-1.yaml
@@ -127,7 +127,10 @@ externalDNS:
   txtPrefix: "prefix-"  # txt-prefix and txt-suffix are mutual exclusive
   # txtSuffix: "-suffix"
   txtWildcardReplacement: "wildcard-"
-  managedRecordTypes: A,CNAME,NS
+  managedRecordTypes:
+    - A
+    - CNAME
+    - NS
 
 pdns:
   nameOverride: ""

--- a/charts/stateless-dns/ci/test-all-possible-values-2.yaml
+++ b/charts/stateless-dns/ci/test-all-possible-values-2.yaml
@@ -127,7 +127,10 @@ externalDNS:
   # txtPrefix: "prefix-"
   txtSuffix: "-suffix"  # txt-prefix and txt-suffix are mutual exclusive
   txtWildcardReplacement: "wildcard-"
-  managedRecordTypes: A,CNAME,NS
+  managedRecordTypes:
+    - A
+    - CNAME
+    - NS
 
 pdns:
   nameOverride: ""

--- a/charts/stateless-dns/templates/external-dns-deployment.yaml
+++ b/charts/stateless-dns/templates/external-dns-deployment.yaml
@@ -72,7 +72,9 @@ spec:
             {{- range $zonename, $zonefile := .Values.zones }}
             - --domain-filter={{ $zonename }}
             {{- end }}
-            - --managed-record-types={{ .Values.externalDNS.managedRecordTypes }}
+            {{- range .Values.externalDNS.managedRecordTypes }}
+            - --managed-record-types={{ . }}
+            {{- end }}
  
             - --registry=txt
             {{- with .Values.externalDNS.txtOwnerId }}

--- a/charts/stateless-dns/values.yaml
+++ b/charts/stateless-dns/values.yaml
@@ -120,7 +120,11 @@ externalDNS:
   txtPrefix: ""  # Each of the entris added by external-dns will create a TXT entry in the DNS too to mark external-dns as it owner. The TXT entry name will be the entry that is being created plus this prefix.
   txtSuffix: ""  # Same as above but TXT entries are decorated with a suffix instead of a prefix.
   txtWildcardReplacement: ""  # For more information on how TXT entries are created refer to the doc of `txtPrefix`. This is the prefix added to wildcard entries as they cannot be calculated.
-  managedRecordTypes: A,CNAME,NS  # Entry type that external-dns will be able to create in the provider.
+  # Entry types that external-dns will be able to create in the provider.
+  managedRecordTypes:
+    - A
+    - CNAME
+    - NS
 
 pdns:
   nameOverride: ""  # String to override the name of the objects created (will maintain the release name).


### PR DESCRIPTION
`--managed-record-types` needs to be specified multiple times, just like `--domain-filter`.