### PR TITLE
Remove unsupported record types

### DIFF
--- a/charts/stateless-dns/ci/test-all-possible-values-1.yaml
+++ b/charts/stateless-dns/ci/test-all-possible-values-1.yaml
@@ -126,8 +126,7 @@ externalDNS:
   txtWildcardReplacement: "wildcard-"
   managedRecordTypes:
     - A
-    - CNAME
-    - NS
+    - TXT
 
   extraArgs: []
 

--- a/charts/stateless-dns/ci/test-all-possible-values-2.yaml
+++ b/charts/stateless-dns/ci/test-all-possible-values-2.yaml
@@ -126,8 +126,7 @@ externalDNS:
   txtWildcardReplacement: "wildcard-"
   managedRecordTypes:
     - A
-    - CNAME
-    - NS
+    - TXT
 
   extraArgs: []
 

--- a/charts/stateless-dns/values.yaml
+++ b/charts/stateless-dns/values.yaml
@@ -117,7 +117,6 @@ externalDNS:
   triggerLoopOnEvent: true  # Make external-dns to act by reacting to cluster events besides the polling with the interval above.
   policy: sync  # How DNS records are synchronized between sources and providers. sync will delete entries created by external-dns, it could also destroy entries that are not owner by external-dns if at some point it mark it as owned. upsert-only will create entries but will prevent the deletion of them.
   txtOwnerId: ""  # Each of the entries added by external-dns will create a TXT entry in the DNS too to mark external-dns as it owner. This is an ID that will be added to that TXT entry.
-  # Each of the entries added by external-dns will create a TXT entry in the DNS too to mark external-dns as it owner. The TXT entry name will be the entry that is being created plus this prefix.
   # external-dns needs to add to the TXT registry the record type (A, NS, etc.) of the original record in order to have
   # separate TXTs for different record types with the same name. If the special token `%{record_type}` is not specified
   # in this prefix, external-dns will add it automatically to the domain name, e.g. `test-ns.local` for `test.local NS`.
@@ -126,14 +125,14 @@ externalDNS:
   # 1. End with a dot (`.`), so all TXT records belong to the top level zone.
   # 2. Contain the `%{record_type}` token before that dot.
   # 3. Ensure a blank `%{record_type}` does not leave trailing or leading dots or dashes, or two consecutive dashes.
-  txtPrefix: "in%{record_type}.stateless-dns."
+  txtPrefix: "in%{record_type}.stateless-dns."  # Each of the entries added by external-dns will create a TXT entry in the DNS too to mark external-dns as it owner. The TXT entry name will be the entry that is being created plus this prefix. For furhter information of this default, please, refer to the long comment inside `values.yaml`
   txtSuffix: ""  # Same as above but TXT entries are decorated with a suffix instead of a prefix.
   txtWildcardReplacement: ""  # For more information on how TXT entries are created refer to the doc of `txtPrefix`. This is the prefix added to wildcard entries as they cannot be calculated.
-  # Entry types that external-dns will be able to create in the provider.
-  managedRecordTypes:
+  # external-dns refuses to send records that has a trailing dot.
+  # PowerDNS refuses to accept domain without a trailing dot.
+  # That makes impossible to support NS and MX types. So these types have to be in the declared at "zones" in the values.
+  managedRecordTypes:  # Entry types that external-dns will be able to create in the provider. NS and MX entries are unsupported, for more information read the full explanation in the `values.yaml`.
     - A
-    - CNAME
-    - NS
 
   # Additional arguments to pass to the `external-dns` container.
   extraArgs: []


### PR DESCRIPTION
With the test suite I tried to support and test `NS` and `MX` records.

With this installation is impossible. I tried create NS record using this CRD:
```yaml
apiVersion: externaldns.k8s.io/v1alpha1
kind: DNSEndpoint
metadata:
  name: domain-ns
spec:
  endpoints:
    - dnsName: test.es
      recordTTL: 180
      recordType: NS
      targets:
        - ns1.test.es  # exmaple 1
        - ns1.test.es.  # example 2
```

I have not tried with both of the example lines but one of then at a time.

The first example fails because PowerDNS rejects it. This curl replicates the payload that external-dns send to PowerDNS:
```shell
curl -X PATCH --data '{
    "rrsets": [
        {
            "name": "test.es.",
            "type": "NS",
            "ttl": 180,
            "changetype": "REPLACE",
            "records": [
                {
                    "content": "ns1.test.es",
                    "disabled": false
                }
            ]
        }
    ]
}' -H 'X-API-Key: a-testing-apikey' http://$(minikube ip)/api/v1/servers/localhost/zones/test.es. | jq .
```
outputs this error.
```json
{
  "error": "Record test.es./NS 'ns1.test.es': Not in expected format (parsed as 'ns1.test.es.')"
}
```
This is because the trailing dot is missing. If I add it to the payload sent by `curl` to PowerDNS. PowerDNS accepts it and add the record.

So I try the second example, adding a trailing dot to external-dns' CRD but external-dns refuses to send the record and this message can be read in the logs:
```
level=warning msg="Endpoint domain-ns with DNSName test.es has an illegal target. The subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com')"
```

So NS and MX are unsupported and I am removing them.