### PR TITLE
Fix ingress' service backend templating

### DIFF
--- a/charts/stateless-dns/templates/ingress.yaml
+++ b/charts/stateless-dns/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.service.api.enabled .Values.ingress.enabled -}}
-{{- $fullName := include "stateless-dns.fullname" . -}}
+{{- $fullName := (include "stateless-dns.fullname.withSuffix" ( dict "context" . "suffix" "http" )) -}}
 {{- $svcPort := .Values.service.api.port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress


### PR DESCRIPTION
Ingress service is not using the `withSuffix` stanza, hence templating incorrectly compared with the service name.

Ingress was correctly deployed and its status is healthy because the ingress controller set the status, but there are not endpoints:
```
Labels:           app.kubernetes.io/instance=kang
                  app.kubernetes.io/managed-by=Helm
                  app.kubernetes.io/name=stateless-dns
                  argocd.argoproj.io/instance=kang-dns
                  helm.sh/chart=stateless-dns-0.2.3
Namespace:        k-dns
Address:          46.4.181.74
Ingress Class:    kang
Default backend:  <default>
TLS:
  pdns-certs terminates pdns-api.kangmak.es
Rules:
  Host                 Path  Backends
  ----                 ----  --------
  pdns-api.kangmak.es
                       /   kang-stateless-dns:80 (<error: endpoints "kang-stateless-dns" not found>)
Annotations:           cert-manager.io/cluster-issuer: letsencrypt-prod-kang
                       nginx.ingress.kubernetes.io/auth-tls-secret: cert-manager/kang-ca
                       nginx.ingress.kubernetes.io/auth-tls-verify-client: on
Events:                <none>
```