### PR TITLE
Add release toolkit to this repository

### DIFF
--- a/.github/rt-dictionary.yaml
+++ b/.github/rt-dictionary.yaml
@@ -1,0 +1,8 @@
+# This file is a dictionary used by the [link-dependencies](https://github.com/newrelic/release-toolkit/tree/main/link-dependencies) action.
+# Notice that the implementation uses dep.To.ToString that removes the leading v if present.
+dictionary:
+  # TODO: Unable to link dependency for Power DNS because it uses a weird changelog URL scheme:
+  # https://doc.powerdns.com/authoritative/changelog/4.9.html#change-4.9.1
+  # txqueuelen/powerdns-docker: "https://github.com/txqueuelen/powerdns-docker/releases/tag/{{.To}}"
+
+  external-dns/external-dns: "https://github.com/kubernetes-sigs/external-dns/releases/tag/v{{.To}}"

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -44,6 +44,9 @@ jobs:
       next-version: ${{ steps.version.outputs.next-version }}
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
       - name: Validate that the markdown is correct
         uses: newrelic/release-toolkit/validate-markdown@v1
       - name: Generate YAML

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -34,13 +34,52 @@ jobs:
             fi
           done
 
+  changelog-checks:
+    name: Test changelog correctness and get next-version
+    runs-on: ubuntu-latest
+    outputs:
+      is-empty: ${{ steps.empty.outputs.is-empty }}
+      is-held: ${{ steps.held.outputs.is-held }}
+      skip-release: ${{ steps.empty.outputs.is-empty == 'true' || steps.held.outputs.is-held == 'true' }}
+      next-version: ${{ steps.version.outputs.next-version }}
+
+    steps:
+      - name: Validate that the markdown is correct
+        uses: newrelic/release-toolkit/validate-markdown@v1
+      - name: Generate YAML
+        uses: newrelic/release-toolkit/generate-yaml@v1
+        with:
+          excluded-dirs: .github
+          excluded-files: README.md
+          exit-code: "0"
+      - name: Check if the release is empty
+        id: empty
+        uses: newrelic/release-toolkit/is-empty@v1
+      - name: Check if the release is held
+        id: held
+        uses: newrelic/release-toolkit/is-held@v1
+
+      - name: Link dependencies
+        if: ${{ steps.empty.outputs.is-empty == 'true' || steps.held.outputs.is-held == 'true' }}
+        uses: newrelic/release-toolkit/link-dependencies@v1
+        with:
+          dictionary: .github/rt-dictionary.yaml
+
+      - name: Calculate next version
+        if: ${{ steps.empty.outputs.is-empty == 'true' || steps.held.outputs.is-held == 'true' }}
+        id: version
+        uses: newrelic/release-toolkit/next-version@v1
+
   chart-install:
     name: Installation test for Helm charts
     runs-on: ubuntu-latest
     needs:
-      # This test is expensive so only run it when cheap tests pass:
+      # This test is expensive so only run when cheap tests pass.
       - chart-lint
       - chart-unittest
+      # To test the upgrade path we need the previous and next version.
+      - changelog-checks
+    if: ${{ needs.changelog-checks.outputs.skip-release != 'true' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -54,6 +93,11 @@ jobs:
           github token: ${{ secrets.GITHUB_TOKEN }}
           driver: docker
           start args: "--container-runtime=containerd"
+
+      # Change version of the Helm chart to the next one so test upgrade path
+      - name: Set chart version to rt's next-version
+        run: |
+          yq -i '.version = ${{ needs.changelog-checks.outputs.next-version }}' charts/stateless-dns/Chart.yaml
 
       # Test chart installation
       - name: Install helm/chart-testing

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -12,7 +12,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install helm/chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.1
       - name: Lint charts
         run: ct --config .github/ct.yaml lint --all
 
@@ -101,7 +101,7 @@ jobs:
 
       # Test chart installation
       - name: Install helm/chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.1
       - name: Test charts' installation path
         run: |
           ct install --all \

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -65,13 +65,13 @@ jobs:
         uses: newrelic/release-toolkit/is-held@v1
 
       - name: Link dependencies
-        if: ${{ steps.empty.outputs.is-empty == 'true' || steps.held.outputs.is-held == 'true' }}
+        if: ${{ steps.empty.outputs.is-empty == 'false' && steps.held.outputs.is-held == 'false' }}
         uses: newrelic/release-toolkit/link-dependencies@v1
         with:
           dictionary: .github/rt-dictionary.yaml
 
       - name: Calculate next version
-        if: ${{ steps.empty.outputs.is-empty == 'true' || steps.held.outputs.is-held == 'true' }}
+        if: ${{ steps.empty.outputs.is-empty == 'false' && steps.held.outputs.is-held == 'false' }}
         id: version
         uses: newrelic/release-toolkit/next-version@v1
 

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -46,6 +46,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Validate that the markdown is correct
         uses: newrelic/release-toolkit/validate-markdown@v1

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -3,19 +3,6 @@ name: Lint and test PR
 on: pull_request
 
 jobs:
-  chart-lint:
-    name: Lint Helm charts
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Install helm/chart-testing
-        uses: helm/chart-testing-action@v2.6.1
-      - name: Lint charts
-        run: ct --config .github/ct.yaml lint --all
-
   chart-unittest:
     name: Unit test Helm charts
     runs-on: ubuntu-latest
@@ -75,6 +62,26 @@ jobs:
         id: version
         uses: newrelic/release-toolkit/next-version@v1
 
+  chart-lint:
+    name: Lint Helm charts
+    runs-on: ubuntu-latest
+    needs:
+      # Lint charts using the next version.
+      - changelog-checks
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install helm/chart-testing
+        uses: helm/chart-testing-action@v2.6.1
+      # Change version of the Helm chart to the next one so test upgrade path
+      - name: Set chart version to rt's next-version
+        run: |
+          yq -i '.version = "${{ needs.changelog-checks.outputs.next-version }}"' charts/stateless-dns/Chart.yaml
+      - name: Lint charts
+        run: ct --config .github/ct.yaml lint --all
+
   chart-install:
     name: Installation test for Helm charts
     runs-on: ubuntu-latest
@@ -102,7 +109,7 @@ jobs:
       # Change version of the Helm chart to the next one so test upgrade path
       - name: Set chart version to rt's next-version
         run: |
-          yq -i '.version = ${{ needs.changelog-checks.outputs.next-version }}' charts/stateless-dns/Chart.yaml
+          yq -i '.version = "${{ needs.changelog-checks.outputs.next-version }}"' charts/stateless-dns/Chart.yaml
 
       # Test chart installation
       - name: Install helm/chart-testing

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -1,30 +1,80 @@
-# Publish chart as OCI image to GitHub registry. Version is automatically gathered from the tag name.
-# For this workflow to work, GITHUB_TOKEN needs to be configured with write permissions.
-# Additionally, the repository must be granted access in the package settings.
-
 name: Publish chart
 
 on:
   release:
     types: [ released ]
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   release:
     name: Publish chart to OCI registry
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # Create release-toolkit data file and hydrate it.
+      - name: Generate changelog YAML
+        uses: newrelic/release-toolkit/generate-yaml@v1
+        with:
+          excluded-dirs: .github
+          excluded-files: README.md
+          exit-code: "0"
+      - name: Link dependencies
+        if: ${{ steps.empty.outputs.is-empty == 'true' || steps.held.outputs.is-held == 'true' }}
+        uses: newrelic/release-toolkit/link-dependencies@v1
+        with:
+          dictionary: .github/rt-dictionary.yaml
+
+      # Check if we have something to release and if the release is not blocked.
+      - name: Check if the release is empty
+        id: empty
+        uses: newrelic/release-toolkit/is-empty@v1
+      - name: Check if the release is held
+        id: held
+        uses: newrelic/release-toolkit/is-held@v1
+
+      # Calculate next-version and generate change logs
+      - name: Calculate next version
+        if: ${{ steps.empty.outputs.is-empty == 'true' || steps.held.outputs.is-held == 'true' }}
+        id: version
+        uses: newrelic/release-toolkit/next-version@v1
+      - name: Generate release notes
+        if: ${{ steps.empty.outputs.is-empty == 'true' || steps.held.outputs.is-held == 'true' }}
+        uses: newrelic/release-toolkit/render@v1
+      - name: Update CHANGELOG.md
+        if: ${{ steps.empty.outputs.is-empty == 'true' || steps.held.outputs.is-held == 'true' }}
+        uses: newrelic/release-toolkit/update-markdown@v1
+        with:
+          next-version: ${{ steps.next-version.outputs.version }}
+
+      # Commit to main branch and push changes. Then create a release.
+      - name: Commit and tag release
+        if: ${{ steps.empty.outputs.is-empty == 'true' || steps.held.outputs.is-held == 'true' }}
+        run: |
+          git add CHANGELOG.md
+          git commit -m "[no ci] Automatic ${{ steps.next-version.outputs.next-version }} release"
+          git push
+          gh release create "${{ steps.next-version.outputs.next-version }}" -F CHANGELOG.partial.md
+
+      # Login to GitHub Packages to upload the chart to the OCI repository.
       - name: Helm login
+        if: ${{ steps.empty.outputs.is-empty == 'true' || steps.held.outputs.is-held == 'true' }}
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | \
           helm registry login ghcr.io \
             --username "$GITHUB_REPOSITORY_OWNER" \
             --password-stdin
       - name: Helm package
+        if: ${{ steps.empty.outputs.is-empty == 'true' || steps.held.outputs.is-held == 'true' }}
         run: |
-          helm package charts/stateless-dns -u --version "${GITHUB_REF_NAME#v}"
+          helm package charts/stateless-dns -u --version "${{ steps.next-version.outputs.version }}"
       - name: Helm push
+        if: ${{ steps.empty.outputs.is-empty == 'true' || steps.held.outputs.is-held == 'true' }}
         run: |
           helm push \
-          "stateless-dns-${GITHUB_REF_NAME#v}.tgz" \
-          "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts"
+          "stateless-dns-${{ steps.next-version.outputs.version }}.tgz" \
+          "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/pdns-stateless"

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       # Create release-toolkit data file and hydrate it.
       - name: Generate changelog YAML

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Release toolkit
+/changelog.yaml
+/CHANGELOG.partial.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,5 +25,5 @@ Luckily there are only a few 0ver releases from here once we merge all
 dependencies that need to be upgraded and make the last changes before
 creating the v1 release :D
 
-### Enhancements
+### Enhancement
 - Automatic dependency upgrade and release system

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+## Unreleased
+
+### Note
+
+All the previous release contain no changelog as it was no automation.
+
+I am solving this with this PR/release/automation that automates the
+generation of change logs and releases.
+
+I am leveraging this 0ver to do a breaking change. I am changing the
+URL for this chart from oci://ghcr.io/txqueuelen/charts to
+oci://ghcr.io/txqueuelen/pdns-stateless.
+
+It seemed that is awesome to have all charts on the same path and loved
+that Github supported it but I found that is hard to follow the origin
+of a chart. Users expect to have the chart in a repository called
+`charts`.
+
+This breaking change should not affect too much as almost no user is
+using this release note is a way of documenting the changes.
+
+Luckily there are only a few 0ver releases from here once we merge all
+dependencies that need to be upgraded and make the last changes before
+creating the v1 release :D
+
+### Enhancements
+- Automatic dependency upgrade and release system


### PR DESCRIPTION
On this PR I wish to have change logs automated so I can enable renovatebot and have readable Changelogs for this chart.

Software like Power DNS is [still being updated and released](https://github.com/txqueuelen/powerdns-docker/pkgs/container/powerdns-docker%2Fpowerdns) and is not being update on this chart.

I would also have a PR from renovate each time that `external-dns` release a version so I can investigate if there is a feature that worth be added to this chart.