### PR TITLE
Split pipelines

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -1,4 +1,4 @@
-name: Publish chart
+name: Create chart release
 
 on:
   push:
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  packages: write
 
 env:
   COMMITTER_NAME: "txqueuelen release bot"
@@ -15,7 +14,7 @@ env:
 
 jobs:
   release:
-    name: Publish chart to OCI registry
+    name: Create chart release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -30,6 +29,7 @@ jobs:
           excluded-dirs: .github
           excluded-files: README.md
           exit-code: "0"
+
       # Check if we have something to release and if the release is not blocked.
       - name: Check if the release is empty
         id: empty
@@ -69,22 +69,3 @@ jobs:
           git commit -m "[no ci] Automatic ${{ steps.version.outputs.next-version }} release"
           git push
           gh release create "${{ steps.version.outputs.next-version }}" -F CHANGELOG.partial.md
-
-      # Login to GitHub Packages to upload the chart to the OCI repository.
-      - name: Helm login
-        if: ${{ steps.empty.outputs.is-empty == 'false' && steps.held.outputs.is-held == 'false' }}
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | \
-          helm registry login ghcr.io \
-            --username "$GITHUB_REPOSITORY_OWNER" \
-            --password-stdin
-      - name: Helm package
-        if: ${{ steps.empty.outputs.is-empty == 'false' && steps.held.outputs.is-held == 'false' }}
-        run: |
-          helm package charts/stateless-dns -u --version "${{ steps.version.outputs.next-version }}"
-      - name: Helm push
-        if: ${{ steps.empty.outputs.is-empty == 'false' && steps.held.outputs.is-held == 'false' }}
-        run: |
-          helm push \
-          "stateless-dns-${{ steps.version.outputs.next-version }}.tgz" \
-          "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/pdns-stateless"

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -1,0 +1,30 @@
+name: Publish chart
+
+on:
+  release:
+    types:
+      - released
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Publish chart to OCI registry
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Helm login
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+          helm registry login ghcr.io \
+            --username "$GITHUB_REPOSITORY_OWNER" \
+            --password-stdin
+      - name: Helm package
+        run: |
+          helm package charts/stateless-dns -u --version "${GITHUB_REF_NAME#v}"
+      - name: Helm push
+        run: |
+          helm push \
+          "stateless-dns-${GITHUB_REF_NAME#v}.tgz" \
+          "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/pdns-stateless"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Enhancement
+- Split release process so we can create off-tree emergency releases
+
 ## v0.4.1 - 2024-06-18
 
 ### ⛓️ Dependencies
@@ -11,10 +14,15 @@
 
 ### Note
 All the previous release contain no changelog as it was no automation.
+
 I am solving this with this PR/release/automation that automates the generation of change logs and releases.
+
 I am leveraging this 0ver to do a breaking change. I am changing the URL for this chart from oci://ghcr.io/txqueuelen/charts to oci://ghcr.io/txqueuelen/pdns-stateless.
+
 It seemed that is awesome to have all charts on the same path and loved that Github supported it but I found that is hard to follow the origin of a chart. Users expect to have the chart in a repository called `charts`.
+
 This breaking change should not affect too much as almost no user is using this release note is a way of documenting the changes.
+
 Luckily there are only a few 0ver releases from here once we merge all dependencies that need to be upgraded and make the last changes before creating the v1 release :D
 
 ### 🚀 Enhancements


### PR DESCRIPTION
This for maintenance purposes, we split the pipelines so one creates a release and a release pipelines actually uploads the chart from a release to a package repository.

This is not only to free the pipeline from some responsibility and keep things tidy but also to be able to re-run pipelines if needed.

## Note for the reviewer

As I am reusing a file name, `git diff` is doing a diff of the whole file. It is easy to read if you go commit by commit.