### PR TITLE
Upgrade external-dns to 0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Enhancement
+- Upgrade external-dns to 0.14.2
+
+### Note
+We are upgrading changing the bare minimum to make it work. We still have to re-read
+all the changelog and add all new features to this chart (or migrate to the one
+upstream if we can).
+
 ## v0.4.1 - 2024-06-18
 
 ### ⛓️ Dependencies

--- a/charts/stateless-dns/crds/crds.yaml
+++ b/charts/stateless-dns/crds/crds.yaml
@@ -1,13 +1,9 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
-    api-approved.kubernetes.io: "https://github.com/kubernetes-sigs/external-dns/pull/2007"
-  creationTimestamp: null
   name: dnsendpoints.externaldns.k8s.io
+  annotations:
+    api-approved.kubernetes.io: "https://github.com/kubernetes-sigs/external-dns/pull/2007"
 spec:
   group: externaldns.k8s.io
   names:
@@ -86,9 +82,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/stateless-dns/values.yaml
+++ b/charts/stateless-dns/values.yaml
@@ -73,7 +73,7 @@ externalDNS:
   image:
     registry: registry.k8s.io  # Image registry
     repository: external-dns/external-dns  # Image repository
-    tag: v0.13.4  # Image tag
+    tag: v0.14.2  # Image tag
 
   pullPolicy: IfNotPresent  # Image pull policy.
 
@@ -131,6 +131,8 @@ externalDNS:
   # During the testing we were able to create only "A" and "TXT" records with this setup.
   managedRecordTypes:  # Entry types that external-dns will be able to create in the provider. NS and MX entries are unsupported, for more information read the full explanation in the `values.yaml`.
     - A
+    - AAAA
+    - CNAME
 
   # Additional arguments to pass to the `external-dns` container.
   extraArgs: []


### PR DESCRIPTION
We are upgrading changing the bare minimum to make it work. We still have to re-read all the changelog and add all new features to this chart (or migrate to the one upstream if we can).
