### PR TITLE
allow defining `ipFamilyPolicy` for services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Enhancement
+- Allow specifying `ipFamilyPolicy` on all services.
+
 ## v0.5.1 - 2024-08-09
 
 ### ⛓️ Dependencies

--- a/charts/stateless-dns/templates/services.yaml
+++ b/charts/stateless-dns/templates/services.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- include "stateless-dns.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.dnsUdp.type }}
+  {{- with .Values.service.dnsUdp.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . | quote }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.dnsUdp.port }}
       targetPort: dns-udp
@@ -37,6 +40,9 @@ metadata:
     {{- include "stateless-dns.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.dnsTcp.type }}
+  {{- with .Values.service.dnsTcp.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . | quote }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.dnsTcp.port }}
       targetPort: dns-tcp
@@ -61,6 +67,9 @@ metadata:
     {{- include "stateless-dns.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.api.type }}
+  {{- with .Values.service.api.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . | quote }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.api.port }}
       targetPort: http
@@ -85,6 +94,9 @@ metadata:
     {{- include "stateless-dns.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.externalDNSMetrics.type }}
+  {{- with .Values.service.externalDNSMetrics.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . | quote }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.externalDNSMetrics.port }}
       targetPort: metrics-http

--- a/charts/stateless-dns/values.yaml
+++ b/charts/stateless-dns/values.yaml
@@ -32,23 +32,28 @@ service:
   api:
     enabled: true  # Specifies whether a service that points to the http port of pdns http API should be created. It is separated from the other services so the user can select service type freely from the others needed.
     type: ClusterIP  # Service type.
+    # ipFamilyPolicy can be defined as below. If ommited, it will not be rendered in yaml.
+    # ipFamilyPolicy: SingleStack
     port: 80  # Service port.
     annotations: {}  # Annotations to add to the service.
 
   dnsUdp:
     enabled: true  # Specifies whether a service that points to the UDP port of pdns should be created. It is separated from TCP DNS port because of limitations of Kubernetes. You cannot create a service with type LoadBalancer that exposes UDP and TCP ports at the same time. Two services should workaround this limitation.
+    # ipFamilyPolicy: SingleStack
     type: ClusterIP  # Service type.
     port: 53  # Service port.
     annotations: {}  # Annotations to add to the service.
 
   dnsTcp:
     enabled: true  # Specifies whether a service that points to the TCP port of pdns should be created. It is separated from UDP DNS port because of limitations of Kubernetes. You cannot create a service with type LoadBalancer that exposes UDP and TCP ports at the same time. Two services should workaround this limitation.
+    # ipFamilyPolicy: SingleStack
     type: ClusterIP  # Service type.
     port: 53  # Service port.
     annotations: {}  # Annotations to add to the service.
 
   externalDNSMetrics:
     enabled: true  # Specifies whether a service that points to the http port of external-dns prometheus metrics.
+    # ipFamilyPolicy: SingleStack
     type: ClusterIP  # Service type.
     port: 80  # Service port.
     annotations: {}  # Annotations to add to the service.


### PR DESCRIPTION
This is needed for LoadBalancer services on DualStack clusters to have both an v4 and a v6 address.

Closes #94 