### PR TITLE
renovatebot: merge docker upgrades automatically

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,7 +9,7 @@
 
   // Using the kubernetes manager with all yaml files.
   "kubernetes": {
-    "fileMatch": [ "\\.yaml$" ]
+    "managerFilePatterns": [ "/\\.ya?ml$/" ]
   },
 
   // Update minikube action parameters.
@@ -35,6 +35,16 @@
       ],
       "groupName": "Kubernetes related testing dependencies",
       "groupSlug": "kubernetes-ci"
+    },
+    {
+      "matchPackageNames": [
+        "powerdns",
+        "external-dns"
+      ],
+      "matchUpdateTypes": [ "minor" ],
+      "automerge": true,
+      "automergeType": "branch",
+      "pruneBranchAfterAutomerge": true,
     }
   ]
 }


### PR DESCRIPTION
Added a rule to automatically merge all dependencies (at least to minor versions)

We know that external-dns is 0ver software but we have tests to be sure that what we need is covered.

I also made a config migration that renovate asked me to do on a different repository.